### PR TITLE
AND-3763 | library improvisation changes

### DIFF
--- a/sipservice/src/main/java/com/phone/sip/BroadcastEventEmitter.java
+++ b/sipservice/src/main/java/com/phone/sip/BroadcastEventEmitter.java
@@ -8,6 +8,7 @@ import android.content.pm.ResolveInfo;
 import android.os.Parcelable;
 
 import com.phone.sip.constants.CallEvent;
+import com.phone.sip.constants.InitializeStatus;
 import com.phone.sip.constants.SipServiceConstants;
 import com.phone.sip.model.IncomingCallData;
 import com.phone.sip.model.MissedCallData;
@@ -45,13 +46,14 @@ public class BroadcastEventEmitter implements SipServiceConstants {
         CALL_RECONNECTION_STATE,
         SILENT_CALL_STATUS,
         NOTIFY_TLS_VERIFY_STATUS_FAILED,
-        CALLBACK_SET_ACCOUNT,
         CALLBACK_REMOVE_ACCOUNT,
         INCOMING_CALL_NOTIFICATION_CLICK,
         ACCEPT_INCOMING_CALL_ACTION,
         END_SERVICE_ACTION,
         CALL_MEDIA_EVENT,
-        CALLBACK_GENERIC_ERROR
+        CALLBACK_GENERIC_ERROR,
+
+        INITIALIZE
     }
 
     public BroadcastEventEmitter(Context context) {
@@ -100,7 +102,7 @@ public class BroadcastEventEmitter implements SipServiceConstants {
      * Emit an incoming call broadcast intent.
      *
      * @param incomingCallData {@link IncomingCallData}
-     * @param isAnyActiveCall Any active call present (true/false)
+     * @param isAnyActiveCall  Any active call present (true/false)
      */
     public void incomingCall(final IncomingCallData incomingCallData, boolean isAnyActiveCall) {
         final Intent intent = new Intent();
@@ -298,10 +300,10 @@ public class BroadcastEventEmitter implements SipServiceConstants {
         sendExplicitBroadcast(intent);
     }
 
-    void setAccount(SipAccountData data) {
+    void onInitialize(InitializeStatus initializeStatus) {
         final Intent intent = new Intent();
-        intent.setAction(getAction(BroadcastAction.CALLBACK_SET_ACCOUNT));
-        intent.putExtra(PARAM_USERNAME, data.getUsername());
+        intent.setAction(getAction(BroadcastAction.INITIALIZE));
+        intent.putExtra(PARAM_INITIALIZE_STATUS, initializeStatus);
         sendExplicitBroadcast(intent);
     }
 
@@ -318,7 +320,7 @@ public class BroadcastEventEmitter implements SipServiceConstants {
      * @param mediaEventType Type of mediaEvent  {@link org.pjsip.pjsua2.pjmedia_event_type}
      */
     public void callMediaEvent(int mediaEventType) {
-        Logger.debug(TAG, "sendCallMediaEvent : "+mediaEventType);
+        Logger.debug(TAG, "sendCallMediaEvent : " + mediaEventType);
         final Intent intent = new Intent();
         intent.putExtra(PARAM_CALL_MEDIA_EVENT_TYPE, mediaEventType);
         intent.setAction(getAction(BroadcastAction.CALL_MEDIA_EVENT));

--- a/sipservice/src/main/java/com/phone/sip/BroadcastEventReceiver.java
+++ b/sipservice/src/main/java/com/phone/sip/BroadcastEventReceiver.java
@@ -10,6 +10,7 @@ import android.content.IntentFilter;
 import androidx.annotation.NonNull;
 
 import com.phone.sip.constants.CallEvent;
+import com.phone.sip.constants.InitializeStatus;
 import com.phone.sip.constants.SipServiceConstants;
 import com.phone.sip.model.IncomingCallData;
 import com.phone.sip.model.MissedCallData;
@@ -37,8 +38,8 @@ public class BroadcastEventReceiver extends BroadcastReceiver implements SipServ
 
         String action = intent.getAction();
 
-        if (BroadcastEventEmitter.getAction(BroadcastEventEmitter.BroadcastAction.CALLBACK_SET_ACCOUNT).equals(action)) {
-            onSetAccount(intent.getStringExtra(PARAM_USERNAME));
+        if (BroadcastEventEmitter.getAction(BroadcastEventEmitter.BroadcastAction.INITIALIZE).equals(action)) {
+            onInitialize(intent.getParcelableExtra(PARAM_INITIALIZE_STATUS));
         } else if (BroadcastEventEmitter.getAction(BroadcastEventEmitter.BroadcastAction.REGISTRATION).equals(action)) {
             int stateCode = intent.getIntExtra(PARAM_REGISTRATION_CODE, -1);
             onRegistration(intent.getStringExtra(PARAM_ACCOUNT_ID), stateCode);
@@ -149,7 +150,7 @@ public class BroadcastEventReceiver extends BroadcastReceiver implements SipServ
         intentFilter.addAction(BroadcastEventEmitter.getAction(
                 BroadcastEventEmitter.BroadcastAction.NOTIFY_TLS_VERIFY_STATUS_FAILED));
         intentFilter.addAction(BroadcastEventEmitter.getAction(
-                BroadcastEventEmitter.BroadcastAction.CALLBACK_SET_ACCOUNT));
+                BroadcastEventEmitter.BroadcastAction.INITIALIZE));
         intentFilter.addAction(BroadcastEventEmitter.getAction(
                 BroadcastEventEmitter.BroadcastAction.CALLBACK_REMOVE_ACCOUNT));
         intentFilter.addAction(BroadcastEventEmitter.getAction(
@@ -204,7 +205,7 @@ public class BroadcastEventReceiver extends BroadcastReceiver implements SipServ
     }
 
     public void onCallEvent(final CallEvent event) {
-        Logger.debug(LOG_TAG, "onCallEvent - "+event.toString());
+        Logger.debug(LOG_TAG, "onCallEvent - " + event.toString());
     }
 
     public void onCallMediaState(String accountID, int callID, MediaState stateType, boolean stateValue) {
@@ -274,7 +275,11 @@ public class BroadcastEventReceiver extends BroadcastReceiver implements SipServ
         Logger.debug(LOG_TAG, "TlsVerifyStatusFailed");
     }
 
-    public void onSetAccount(String username) {
-        Logger.debug(LOG_TAG, "onSetAccount - username: " + getValue(getReceiverContext(), username));
+    public void onInitialize(InitializeStatus initializeStatus) {
+        if (initializeStatus instanceof InitializeStatus.Success) {
+            Logger.debug(LOG_TAG, "onInitialize - SUCCESS: " + ((InitializeStatus.Success) initializeStatus).getUsername());
+        } else if (initializeStatus instanceof InitializeStatus.Failure) {
+            Logger.debug(LOG_TAG, "onInitialize - FAILURE: " + ((InitializeStatus.Failure) initializeStatus).getErrorMessage());
+        }
     }
 }

--- a/sipservice/src/main/java/com/phone/sip/PhoneComService.kt
+++ b/sipservice/src/main/java/com/phone/sip/PhoneComService.kt
@@ -7,9 +7,9 @@ import com.phone.sip.models.ConfigureSip
 
 class PhoneComService(
     var context: Context? = null,
-    var configurePushNotification: ConfigureFCMPushNotification? = null,
-    var configureSip: ConfigureSip? = null,
-    var configureServiceNotification: ConfigurePhoneServiceNotification? = null
+    var configurePushNotification: ConfigureFCMPushNotification,
+    var configureSip: ConfigureSip,
+    var configureServiceNotification: ConfigurePhoneServiceNotification
 ) {
 
     private constructor(builder: Builder) : this(
@@ -22,11 +22,11 @@ class PhoneComService(
     class Builder {
         var context: Context? = null
             private set
-        var configurePushNotification: ConfigureFCMPushNotification? = null
+        lateinit var configurePushNotification: ConfigureFCMPushNotification
             private set
-        var configureSip: ConfigureSip? = null
+        lateinit var configureSip: ConfigureSip
             private set
-        var configureServiceNotification: ConfigurePhoneServiceNotification? = null
+        lateinit var configureServiceNotification: ConfigurePhoneServiceNotification
             private set
 
         fun setFcmRegistrationDetails(configurePushNotification: ConfigureFCMPushNotification) =
@@ -42,31 +42,19 @@ class PhoneComService(
 
         fun build(context: Context): PhoneComService {
             this.context = context
-            if (configurePushNotification != null) {
-                PhoneComServiceCommand.saveInformationForPushRegistration(
-                    configurePushNotification,
-                    context
-                )
-            } else {
-                throw Exception("Missing Push notification parameters.")
-            }
+            PhoneComServiceCommand.saveInformationForPushRegistration(
+                configurePushNotification,
+                context
+            )
 
-            if (configureSip != null) {
-                PhoneComServiceCommand.saveInformationForSipLibraryInitialization(
-                    configureSip,
-                    context
-                )
-            } else {
-                throw Exception("Missing SIP configuration parameters.")
-            }
+            PhoneComServiceCommand.saveInformationForSipLibraryInitialization(
+                configureSip,
+                context
+            )
 
-            if (configureServiceNotification != null) {
-                PhoneComServiceCommand.saveInformationForForegroundServiceNotification(
-                    configureServiceNotification, context
-                )
-            } else {
-                throw Exception("Missing phone service notification parameters.")
-            }
+            PhoneComServiceCommand.saveInformationForForegroundServiceNotification(
+                configureServiceNotification, context
+            )
 
             return PhoneComService(this)
         }

--- a/sipservice/src/main/java/com/phone/sip/SipService.java
+++ b/sipservice/src/main/java/com/phone/sip/SipService.java
@@ -15,6 +15,7 @@ import android.os.Looper;
 import android.view.Surface;
 
 import com.phone.sip.constants.CallEvent;
+import com.phone.sip.constants.InitializeStatus;
 import com.phone.sip.constants.SipServiceConstants;
 import com.phone.sip.model.IncomingCallData;
 import com.phone.sip.model.MissedCallData;
@@ -1103,10 +1104,11 @@ public class SipService extends BackgroundService implements SipServiceConstants
                 addAccount(data);
                 mConfiguredAccounts.add(data);
                 persistConfiguredAccounts();
-                mBroadcastEmitter.setAccount(data);
+                mBroadcastEmitter.onInitialize(new InitializeStatus.Success(data.getUsername()));
             } catch (Exception exc) {
                 Logger.error(TAG, "Error while adding " + getValue(getApplicationContext(), data.getIdUri(getApplicationContext())), exc);
                 enqueueDelayedJob(() -> stopForeground(false), SipServiceConstants.DELAY_STOP_SERVICE);
+                mBroadcastEmitter.onInitialize(new InitializeStatus.Failure("Error while adding " + getValue(getApplicationContext(), data.getIdUri(getApplicationContext()))));
                 return;
             }
         } else {
@@ -1118,9 +1120,10 @@ public class SipService extends BackgroundService implements SipServiceConstants
                 addAccount(data);
                 mConfiguredAccounts.set(index, data);
                 persistConfiguredAccounts();
-                mBroadcastEmitter.setAccount(data);
+                mBroadcastEmitter.onInitialize(new InitializeStatus.Success(data.getUsername()));
             } catch (Exception exc) {
                 Logger.error(TAG, "Error while reconfiguring " + getValue(getApplicationContext(), data.getIdUri(getApplicationContext())), exc);
+                mBroadcastEmitter.onInitialize(new InitializeStatus.Failure("Error while adding " + getValue(getApplicationContext(), data.getIdUri(getApplicationContext()))));
                 enqueueDelayedJob(() -> stopForeground(false), SipServiceConstants.DELAY_STOP_SERVICE);
                 return;
             }

--- a/sipservice/src/main/java/com/phone/sip/constants/InitializeStatus.kt
+++ b/sipservice/src/main/java/com/phone/sip/constants/InitializeStatus.kt
@@ -1,0 +1,12 @@
+package com.phone.sip.constants
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+sealed class InitializeStatus : Parcelable {
+    @Parcelize
+    class Success(var username: String) : InitializeStatus()
+
+    @Parcelize
+    class Failure(var errorMessage: String) : InitializeStatus()
+}

--- a/sipservice/src/main/java/com/phone/sip/constants/SipServiceConstants.java
+++ b/sipservice/src/main/java/com/phone/sip/constants/SipServiceConstants.java
@@ -92,7 +92,7 @@ public interface SipServiceConstants {
     String PARAM_CALL_MEDIA_EVENT_TYPE = "callMediaEventType";
     String PARAM_INCOMING_CALL_DATA = "incomingCallData";
     String PARAM_MISSED_CALL_DATA = "missedCallData";
-
+    String PARAM_INITIALIZE_STATUS = "initializeStatus";
 
     /**
      * Specific Parameters passed in the broadcast intents for call stats.

--- a/sipservice/src/main/java/com/phone/sip/models/ConfigureFCMPushNotification.kt
+++ b/sipservice/src/main/java/com/phone/sip/models/ConfigureFCMPushNotification.kt
@@ -1,12 +1,22 @@
 package com.phone.sip.models
 
+import org.jetbrains.annotations.NotNull
+
 data class ConfigureFCMPushNotification(
+    @NotNull
     var pushToken: String,
+    @NotNull
     var versionName: String,
+    @NotNull
     var bundleID: String,
+    @NotNull
     var deviceInfo: String,
+    @NotNull
     var applicationID: String,
+    @NotNull
     var deviceType: String,
+    @NotNull
     var voipId: String,
+    @NotNull
     var voipPhoneID: String
 )

--- a/sipservice/src/main/java/com/phone/sip/models/ConfigurePhoneServiceNotification.kt
+++ b/sipservice/src/main/java/com/phone/sip/models/ConfigurePhoneServiceNotification.kt
@@ -1,7 +1,12 @@
 package com.phone.sip.models
 
+import org.jetbrains.annotations.NotNull
+
 data class ConfigurePhoneServiceNotification(
+    @NotNull
     var appName: String,
+    @NotNull
     var notificationMessage: String,
+    @NotNull
     var notificationIcon: Int
 )

--- a/sipservice/src/main/java/com/phone/sip/models/ConfigureSip.kt
+++ b/sipservice/src/main/java/com/phone/sip/models/ConfigureSip.kt
@@ -1,11 +1,20 @@
 package com.phone.sip.models
 
+import org.jetbrains.annotations.NotNull
+
 data class ConfigureSip(
+    @NotNull
     var sipUsername: String,
+    @NotNull
     var sipPassword: String,
+    @NotNull
     var domainName: String,
+    @NotNull
     var port: Int,
+    @NotNull
     var securePort: Int,
+    @NotNull
     var secureProtocolName: String,
+    @NotNull
     var protocolName: String
 )


### PR DESCRIPTION
Added 2 changes in this PR,
1. While initializing the library, added non-null params for all required items of the models of `ConfigureFCMPushNotification`, `ConfigureSip` & `ConfigurePhoneServiceNotification`
2. Removed setAccount() callback method and added onInitialize() method with Success and Failure type with proper message 