### PR TITLE
AND-3900 | Added the apis for verbose and file logging

### DIFF
--- a/sipservice/src/main/java/com/phone/sip/PhoneComLogger.kt
+++ b/sipservice/src/main/java/com/phone/sip/PhoneComLogger.kt
@@ -1,0 +1,53 @@
+package com.phone.sip
+
+import android.content.Context
+
+class PhoneComLogger(
+    var context: Context? = null,
+    var enableSipConsoleLogging: Boolean,
+    var enableSipFileLogging: Boolean,
+    var logFilePath: String
+) {
+
+    private constructor(builder: Builder) : this(
+        builder.context,
+        builder.enableSipConsoleLogging,
+        builder.enableSipFileLogging,
+        builder.logFilePath
+    )
+
+    class Builder {
+        var context: Context? = null
+            private set
+        var enableSipConsoleLogging: Boolean = false
+            private set
+        var enableSipFileLogging: Boolean = false
+            private set
+        var logFilePath: String = ""
+            private set
+
+        fun setContext(context: Context) = apply { this.context = context }
+
+        fun setSipFileLoggingEnabled(enableSipFileLogging: Boolean, logFilePath: String) = apply {
+            this.enableSipFileLogging = enableSipFileLogging
+            this.logFilePath = logFilePath
+        }
+
+        fun setSipConsoleLoggingEnabled(enableSipConsoleLogging: Boolean) =
+            apply { this.enableSipConsoleLogging = enableSipConsoleLogging }
+
+        fun build(context: Context): PhoneComLogger {
+            this.context = context
+
+            PhoneComServiceCommand.setSipFileLoggingEnabled(
+                enableSipFileLogging, logFilePath, context
+            )
+
+            PhoneComServiceCommand.setSipConsoleLoggingEnabled(
+                enableSipConsoleLogging, context
+            )
+
+            return PhoneComLogger(this)
+        }
+    }
+}

--- a/sipservice/src/main/java/com/phone/sip/PhoneComLogger.kt
+++ b/sipservice/src/main/java/com/phone/sip/PhoneComLogger.kt
@@ -28,9 +28,9 @@ class PhoneComLogger(
 
         fun setContext(context: Context) = apply { this.context = context }
 
-        fun setSipFileLoggingEnabled(enableSipFileLogging: Boolean, logFilePath: String) = apply {
+        fun setSipFileLoggingEnabled(enableSipFileLogging: Boolean, logFilePath: String? = "") = apply {
             this.enableSipFileLogging = enableSipFileLogging
-            this.logFilePath = logFilePath
+            this.logFilePath = logFilePath ?: ""
         }
 
         fun setSipConsoleLoggingEnabled(enableSipConsoleLogging: Boolean) =

--- a/sipservice/src/main/java/com/phone/sip/PhoneComService.kt
+++ b/sipservice/src/main/java/com/phone/sip/PhoneComService.kt
@@ -8,19 +8,20 @@ import com.phone.sip.models.ConfigureSip
 
 class PhoneComService(
     var context: Context? = null,
-    var configurePushNotification: ConfigureFCMPushNotification?,
     var configureSip: ConfigureSip?,
     var configureServiceNotification: ConfigurePhoneServiceNotification?,
-    var enableSipLogging: Boolean
+    var enableSipConsoleLogging: Boolean,
+    var enableSipFileLogging: Boolean,
+    var logFilePath: String
 ) {
 
     private constructor(builder: Builder) : this(
         builder.context,
-        builder.configurePushNotification,
         builder.configureSip,
         builder.configureServiceNotification,
-        builder.enableSipLogging
-
+        builder.enableSipConsoleLogging,
+        builder.enableSipFileLogging,
+        builder.logFilePath
     )
 
     class Builder {
@@ -32,7 +33,11 @@ class PhoneComService(
             private set
         var configureServiceNotification: ConfigurePhoneServiceNotification? = null
             private set
-        var enableSipLogging: Boolean = false
+        var enableSipConsoleLogging: Boolean = false
+            private set
+        var enableSipFileLogging: Boolean = false
+            private set
+        var logFilePath: String = ""
             private set
 
         fun setFcmRegistrationDetails(configurePushNotification: ConfigureFCMPushNotification) =
@@ -46,8 +51,13 @@ class PhoneComService(
 
         fun setContext(context: Context) = apply { this.context = context }
 
-        fun setSipLoggingEnabled(enableSipLogging: Boolean) =
-            apply { this.enableSipLogging = enableSipLogging }
+        fun setSipFileLoggingEnabled(enableSipFileLogging: Boolean, logFilePath: String) = apply {
+            this.enableSipFileLogging = enableSipFileLogging
+            this.logFilePath = logFilePath
+        }
+
+        fun setSipConsoleLoggingEnabled(enableSipConsoleLogging: Boolean) =
+            apply { this.enableSipConsoleLogging = enableSipConsoleLogging }
 
         fun build(context: Context): PhoneComService {
             this.context = context
@@ -70,8 +80,12 @@ class PhoneComService(
                 configureServiceNotification, context
             )
 
-            PhoneComServiceCommand.setSipLoggingEnabled(
-                enableSipLogging, context
+            PhoneComServiceCommand.setSipFileLoggingEnabled(
+                enableSipFileLogging, logFilePath, context
+            )
+
+            PhoneComServiceCommand.setSipConsoleLoggingEnabled(
+                enableSipConsoleLogging, context
             )
 
             return PhoneComService(this)

--- a/sipservice/src/main/java/com/phone/sip/PhoneComService.kt
+++ b/sipservice/src/main/java/com/phone/sip/PhoneComService.kt
@@ -9,19 +9,13 @@ import com.phone.sip.models.ConfigureSip
 class PhoneComService(
     var context: Context? = null,
     var configureSip: ConfigureSip?,
-    var configureServiceNotification: ConfigurePhoneServiceNotification?,
-    var enableSipConsoleLogging: Boolean,
-    var enableSipFileLogging: Boolean,
-    var logFilePath: String
+    var configureServiceNotification: ConfigurePhoneServiceNotification?
 ) {
 
     private constructor(builder: Builder) : this(
         builder.context,
         builder.configureSip,
-        builder.configureServiceNotification,
-        builder.enableSipConsoleLogging,
-        builder.enableSipFileLogging,
-        builder.logFilePath
+        builder.configureServiceNotification
     )
 
     class Builder {
@@ -33,12 +27,7 @@ class PhoneComService(
             private set
         var configureServiceNotification: ConfigurePhoneServiceNotification? = null
             private set
-        var enableSipConsoleLogging: Boolean = false
-            private set
-        var enableSipFileLogging: Boolean = false
-            private set
-        var logFilePath: String = ""
-            private set
+
 
         fun setFcmRegistrationDetails(configurePushNotification: ConfigureFCMPushNotification) =
             apply { this.configurePushNotification = configurePushNotification }
@@ -51,13 +40,6 @@ class PhoneComService(
 
         fun setContext(context: Context) = apply { this.context = context }
 
-        fun setSipFileLoggingEnabled(enableSipFileLogging: Boolean, logFilePath: String) = apply {
-            this.enableSipFileLogging = enableSipFileLogging
-            this.logFilePath = logFilePath
-        }
-
-        fun setSipConsoleLoggingEnabled(enableSipConsoleLogging: Boolean) =
-            apply { this.enableSipConsoleLogging = enableSipConsoleLogging }
 
         fun build(context: Context): PhoneComService {
             this.context = context
@@ -78,14 +60,6 @@ class PhoneComService(
 
             PhoneComServiceCommand.saveInformationForForegroundServiceNotification(
                 configureServiceNotification, context
-            )
-
-            PhoneComServiceCommand.setSipFileLoggingEnabled(
-                enableSipFileLogging, logFilePath, context
-            )
-
-            PhoneComServiceCommand.setSipConsoleLoggingEnabled(
-                enableSipConsoleLogging, context
             )
 
             return PhoneComService(this)

--- a/sipservice/src/main/java/com/phone/sip/PhoneComServiceCommand.java
+++ b/sipservice/src/main/java/com/phone/sip/PhoneComServiceCommand.java
@@ -765,7 +765,7 @@ public final class PhoneComServiceCommand extends ServiceExecutor implements Sip
      * @param context              Activity context
      *                             //@see org.pjsip.pjsua2.app.MyApp#init(MyAppObserver, String, boolean, boolean, Context)
      */
-    public static void setSipFileLoggingEnabled(boolean enableSipFileLogging, @NotNull String logFilePath, @NotNull Context context) {
+     static void setSipFileLoggingEnabled(boolean enableSipFileLogging, @NotNull String logFilePath, @NotNull Context context) {
         if(enableSipFileLogging){
             if(logFilePath.trim().isEmpty()){
                 Logger.error(TAG, ERR_LOG_FILE_NOT_FOUND);

--- a/sipservice/src/main/java/com/phone/sip/PhoneComServiceCommand.java
+++ b/sipservice/src/main/java/com/phone/sip/PhoneComServiceCommand.java
@@ -768,15 +768,8 @@ public final class PhoneComServiceCommand extends ServiceExecutor implements Sip
     public static void setSipFileLoggingEnabled(boolean enableSipFileLogging, @NotNull String logFilePath, @NotNull Context context) {
         if(enableSipFileLogging){
             File file = new File(logFilePath);
-            try {
-                if (!file.exists()) {
-                    boolean isFileCreated = file.createNewFile();
-                    if(!isFileCreated){
-                        Logger.error(TAG, ERR_WRITE_STORAGE_PERMISSION_NOT_ALLOWED);
-                    }
-                }
-            } catch (IOException e) {
-                throw new RuntimeException(e);
+            if (!file.exists()) {
+                Logger.error(TAG, ERR_WRITE_STORAGE_PERMISSION_NOT_ALLOWED);
             }
         }
         SipApplication.setSipFileLoggingEnabled(enableSipFileLogging, logFilePath, context);

--- a/sipservice/src/main/java/com/phone/sip/PhoneComServiceCommand.java
+++ b/sipservice/src/main/java/com/phone/sip/PhoneComServiceCommand.java
@@ -769,7 +769,13 @@ public final class PhoneComServiceCommand extends ServiceExecutor implements Sip
         if(enableSipFileLogging){
             File file = new File(logFilePath);
             if (!file.exists()) {
-                Logger.error(TAG, ERR_WRITE_STORAGE_PERMISSION_NOT_ALLOWED);
+                try {
+                    if(!file.createNewFile()) {
+                        Logger.error(TAG, ERR_WRITE_STORAGE_PERMISSION_NOT_ALLOWED);
+                    }
+                } catch (IOException e) {
+                    Logger.error(TAG, ERR_WRITE_STORAGE_PERMISSION_NOT_ALLOWED);
+                }
             }
         }
         SipApplication.setSipFileLoggingEnabled(enableSipFileLogging, logFilePath, context);

--- a/sipservice/src/main/java/com/phone/sip/PhoneComServiceCommand.java
+++ b/sipservice/src/main/java/com/phone/sip/PhoneComServiceCommand.java
@@ -767,16 +767,26 @@ public final class PhoneComServiceCommand extends ServiceExecutor implements Sip
      */
     public static void setSipFileLoggingEnabled(boolean enableSipFileLogging, @NotNull String logFilePath, @NotNull Context context) {
         if(enableSipFileLogging){
-            File file = new File(logFilePath);
-            if (!file.exists()) {
-                try {
-                    if(!file.createNewFile()) {
+            if(logFilePath.trim().isEmpty()){
+                Logger.error(TAG, ERR_LOG_FILE_NOT_FOUND);
+                new BroadcastEventEmitter(context).errorCallback(ERR_LOG_FILE_NOT_FOUND);
+            } else {
+                File file = new File(logFilePath);
+                if (!file.exists()) {
+                    try {
+                        if(!file.createNewFile()) {
+                            Logger.error(TAG, ERR_WRITE_STORAGE_PERMISSION_NOT_ALLOWED);
+                            new BroadcastEventEmitter(context).errorCallback(ERR_WRITE_STORAGE_PERMISSION_NOT_ALLOWED);
+                        }
+                    } catch (IOException e) {
                         Logger.error(TAG, ERR_WRITE_STORAGE_PERMISSION_NOT_ALLOWED);
+                        new BroadcastEventEmitter(context).errorCallback(ERR_WRITE_STORAGE_PERMISSION_NOT_ALLOWED);
                     }
-                } catch (IOException e) {
-                    Logger.error(TAG, ERR_WRITE_STORAGE_PERMISSION_NOT_ALLOWED);
                 }
             }
+        } else if(!logFilePath.trim().isEmpty()){
+            Logger.error(TAG, ERR_LOG_FILE_FOUND_LOG_DISABLED);
+            new BroadcastEventEmitter(context).errorCallback(ERR_LOG_FILE_FOUND_LOG_DISABLED);
         }
         SipApplication.setSipFileLoggingEnabled(enableSipFileLogging, logFilePath, context);
     }

--- a/sipservice/src/main/java/com/phone/sip/PhoneComServiceCommand.java
+++ b/sipservice/src/main/java/com/phone/sip/PhoneComServiceCommand.java
@@ -11,8 +11,11 @@ import com.phone.sip.models.ConfigureFCMPushNotification;
 import com.phone.sip.models.ConfigurePhoneServiceNotification;
 import com.phone.sip.models.ConfigureSip;
 
+import org.jetbrains.annotations.NotNull;
 import org.pjsip.PjCameraInfo2;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 
 /**
@@ -757,13 +760,26 @@ public final class PhoneComServiceCommand extends ServiceExecutor implements Sip
      * This method sets the file path in sdk for saving the VoIP logs.
      * If file path is a valid path then VoIP logging is enabled,
      * else not
-     *
-     * @param fileName file path for saving the voip logs
-     * @param context  Activity context
-     *                 //@see org.pjsip.pjsua2.app.MyApp#init(MyAppObserver, String, boolean, boolean, Context)
+     * @param enableSipFileLogging to set weather to enable sip logging in provided file or not
+     * @param logFilePath          file path for saving the voip logs
+     * @param context              Activity context
+     *                             //@see org.pjsip.pjsua2.app.MyApp#init(MyAppObserver, String, boolean, boolean, Context)
      */
-    public static void saveInformationForLogFiles(String fileName, Context context) {
-        SipApplication.setLogFilesPathInformation(fileName, context);
+    public static void setSipFileLoggingEnabled(boolean enableSipFileLogging, @NotNull String logFilePath, @NotNull Context context) {
+        if(enableSipFileLogging){
+            File file = new File(logFilePath);
+            try {
+                if (!file.exists()) {
+                    boolean isFileCreated = file.createNewFile();
+                    if(!isFileCreated){
+                        Logger.error(TAG, ERR_WRITE_STORAGE_PERMISSION_NOT_ALLOWED);
+                    }
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        SipApplication.setSipFileLoggingEnabled(enableSipFileLogging, logFilePath, context);
     }
 
     /**
@@ -804,9 +820,9 @@ public final class PhoneComServiceCommand extends ServiceExecutor implements Sip
      * This method is called by client for enabling SIP logging.
      *
      * @param enableSipLogging boolean
-     * @param context {@link android.app.Application} {@link Context}
+     * @param context          {@link android.app.Application} {@link Context}
      */
-    static void setSipLoggingEnabled(boolean enableSipLogging, Context context) {
+    static void setSipConsoleLoggingEnabled(boolean enableSipLogging, Context context) {
         SipApplication.setSipLoggingEnabled(enableSipLogging, context);
     }
 
@@ -875,7 +891,7 @@ public final class PhoneComServiceCommand extends ServiceExecutor implements Sip
         executeSipServiceAction(context, intent);
     }
 
-    public static void holdCall(Context context){
+    public static void holdCall(Context context) {
         final String accountID = SharedPreferencesHelper.getInstance(context).getAccountID();
         checkAccount(accountID);
 
@@ -885,7 +901,7 @@ public final class PhoneComServiceCommand extends ServiceExecutor implements Sip
         executeSipServiceAction(context, intent);
     }
 
-    public static void resumeCall(Context context){
+    public static void resumeCall(Context context) {
         final String accountID = SharedPreferencesHelper.getInstance(context).getAccountID();
         checkAccount(accountID);
 

--- a/sipservice/src/main/java/com/phone/sip/SharedPreferenceConstant.java
+++ b/sipservice/src/main/java/com/phone/sip/SharedPreferenceConstant.java
@@ -24,7 +24,8 @@ public final class SharedPreferenceConstant {
     public static final String NOTIFICATION_ICON = "notificationIcon";
     public static final String PROTOCOL = "protocol";
     public static final String SIP_ACCOUNT_ID = "SIP_ACCOUNT_ID";
-    public static final String ENABLE_SIP_LOGGING = "enableSipLogging";
+    public static final String ENABLE_SIP_CONSOLE_LOGS = "enableSipConsoleLogging";
+    public static final String ENABLE_SIP_FILE_LOGS = "enableSipFileLogging";
 
     private SharedPreferenceConstant() {
     }

--- a/sipservice/src/main/java/com/phone/sip/SipApplication.java
+++ b/sipservice/src/main/java/com/phone/sip/SipApplication.java
@@ -16,6 +16,7 @@ import com.phone.sip.models.ConfigureFCMPushNotification;
 import com.phone.sip.models.ConfigurePhoneServiceNotification;
 import com.phone.sip.models.ConfigureSip;
 
+import org.jetbrains.annotations.NotNull;
 import org.pjsip.pjsua2.SipHeader;
 import org.pjsip.pjsua2.SipHeaderVector;
 
@@ -515,18 +516,20 @@ public final class SipApplication {
 
     private static void setSipLogging(boolean enableSipLogging, Context context) {
         SharedPreferencesHelper.getInstance(context)
-                .putInSharedPreference(SharedPreferenceConstant.ENABLE_SIP_LOGGING, enableSipLogging);
+                .putInSharedPreference(SharedPreferenceConstant.ENABLE_SIP_CONSOLE_LOGS, enableSipLogging);
     }
 
     /**
      * This method is used to set log file name and path to sdk
      *
-     * @param fileName filename for saving logs
+     * @param logFilePath filePath for saving logs
      * @param context  Android context needed
      */
-    public static void setLogFilesPathInformation(String fileName, Context context) {
+    public static void setSipFileLoggingEnabled(boolean enableSipFileLogging, @NotNull String logFilePath, @NotNull Context context) {
         SharedPreferencesHelper.getInstance(context)
-                .putInSharedPreference(SharedPreferenceConstant.LOGS_FILE_NAME, fileName);
+                .putInSharedPreference(SharedPreferenceConstant.ENABLE_SIP_FILE_LOGS, enableSipFileLogging);
+        SharedPreferencesHelper.getInstance(context)
+                .putInSharedPreference(SharedPreferenceConstant.LOGS_FILE_NAME, logFilePath);
     }
 
 
@@ -548,7 +551,7 @@ public final class SipApplication {
      * @param context Android context needed
      * @return path of log file
      */
-    public static String getLogFilePath(Context context) {
+    public static String getLogFileName(Context context) {
         return SharedPreferencesHelper.getInstance(context)
                 .getStringSharedPreference(SharedPreferenceConstant.LOGS_FILE_NAME);
     }

--- a/sipservice/src/main/java/com/phone/sip/SipLogger.java
+++ b/sipservice/src/main/java/com/phone/sip/SipLogger.java
@@ -16,6 +16,7 @@ import org.pjsip.pjsua2.pj_log_decoration;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -48,13 +49,12 @@ class SipLogger extends LogWriter {
                 Logger.error("SIP -> " + entry.getThreadName(), ERR_LOG_FILE_NOT_FOUND);
                 return;
             }
-            try (FileOutputStream fileOutputStream = context.openFileOutput(logFileName, Context.MODE_APPEND)) {
-                fileOutputStream.write("SIP -> ".getBytes(StandardCharsets.UTF_8));
-                fileOutputStream.write(entry.getThreadName().getBytes(StandardCharsets.UTF_8));
-                fileOutputStream.write(entry.getMsg().getBytes(StandardCharsets.UTF_8));
-                fileOutputStream.write("\n\n\n".getBytes(StandardCharsets.UTF_8));
-                fileOutputStream.close();
-                fileOutputStream.flush();
+            try (FileWriter fileWriter = new FileWriter(logFile, true)) {
+                fileWriter.write("SIP -> ");
+                fileWriter.write(entry.getThreadName());
+                fileWriter.write(entry.getMsg());
+                fileWriter.write("\n\n\n");
+                fileWriter.flush();
             } catch (Exception e) {
                 Logger.error("SIP -> " + entry.getThreadName(), ERR_LOG_FILE_NOT_FOUND);
             }

--- a/sipservice/src/main/java/com/phone/sip/SipLogger.java
+++ b/sipservice/src/main/java/com/phone/sip/SipLogger.java
@@ -16,7 +16,7 @@ import org.pjsip.pjsua2.pj_log_decoration;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 
 /**
  * connect
@@ -40,7 +40,7 @@ class SipLogger extends LogWriter {
             File logFile = new File(logFileName);
 
             if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.R &&
-                ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED){
+                    ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
                 Logger.error("SIP -> " + entry.getThreadName(), ERR_WRITE_STORAGE_PERMISSION_NOT_ALLOWED);
             }
 
@@ -48,12 +48,12 @@ class SipLogger extends LogWriter {
                 Logger.error("SIP -> " + entry.getThreadName(), ERR_LOG_FILE_NOT_FOUND);
                 return;
             }
-            try (FileOutputStream fileOutputStream = new FileOutputStream(logFileName, true)) {
-                OutputStreamWriter outputStream = new OutputStreamWriter(fileOutputStream);
-                outputStream.append(entry.getMsg());
-                outputStream.append("\n\n\n");
-                outputStream.flush();
-                outputStream.close();
+            try (FileOutputStream fileOutputStream = context.openFileOutput(logFileName, Context.MODE_APPEND)) {
+                fileOutputStream.write("SIP -> ".getBytes(StandardCharsets.UTF_8));
+                fileOutputStream.write(entry.getThreadName().getBytes(StandardCharsets.UTF_8));
+                fileOutputStream.write(entry.getMsg().getBytes(StandardCharsets.UTF_8));
+                fileOutputStream.write("\n\n\n".getBytes(StandardCharsets.UTF_8));
+                fileOutputStream.close();
                 fileOutputStream.flush();
             } catch (Exception e) {
                 Logger.error("SIP -> " + entry.getThreadName(), ERR_LOG_FILE_NOT_FOUND);
@@ -63,6 +63,7 @@ class SipLogger extends LogWriter {
 
     /**
      * Change decor flags as needed
+     *
      * @return decor flags
      */
     public long getDecor() {

--- a/sipservice/src/main/java/com/phone/sip/SipLogger.java
+++ b/sipservice/src/main/java/com/phone/sip/SipLogger.java
@@ -49,6 +49,9 @@ class SipLogger extends LogWriter {
                 Logger.error("SIP -> " + entry.getThreadName(), ERR_LOG_FILE_NOT_FOUND);
                 return;
             }
+
+
+
             try (FileWriter fileWriter = new FileWriter(logFile, true)) {
                 fileWriter.write("SIP -> ");
                 fileWriter.write(entry.getThreadName());

--- a/sipservice/src/main/java/com/phone/sip/SipLogger.java
+++ b/sipservice/src/main/java/com/phone/sip/SipLogger.java
@@ -1,8 +1,22 @@
 package com.phone.sip;
 
+import static com.phone.sip.constants.SipServiceConstants.ERR_LOG_FILE_NOT_FOUND;
+import static com.phone.sip.constants.SipServiceConstants.ERR_WRITE_STORAGE_PERMISSION_NOT_ALLOWED;
+
+import android.Manifest;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Build;
+
+import androidx.core.content.ContextCompat;
+
 import org.pjsip.pjsua2.LogEntry;
 import org.pjsip.pjsua2.LogWriter;
 import org.pjsip.pjsua2.pj_log_decoration;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
 
 /**
  * connect
@@ -11,8 +25,40 @@ import org.pjsip.pjsua2.pj_log_decoration;
  * Copyright © 2021 VoiSmart S.r.l. All rights reserved.
  */
 class SipLogger extends LogWriter {
+
+    private final Context context;
+
+    public SipLogger(Context context) {
+        this.context = context;
+    }
+
     public void write(LogEntry entry) {
-        Logger.debug("SIP -> "+entry.getThreadName(), entry.getMsg());
+        Logger.debug("SIP -> " + entry.getThreadName(), entry.getMsg());
+
+        if (SharedPreferencesHelper.getInstance(context).getBooleanPreference(SharedPreferenceConstant.ENABLE_SIP_FILE_LOGS, false)) {
+            String logFileName = SharedPreferencesHelper.getInstance(context).getStringSharedPreference(SharedPreferenceConstant.LOGS_FILE_NAME);
+            File logFile = new File(logFileName);
+
+            if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.R &&
+                ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED){
+                Logger.error("SIP -> " + entry.getThreadName(), ERR_WRITE_STORAGE_PERMISSION_NOT_ALLOWED);
+            }
+
+            if (!logFile.exists()) {
+                Logger.error("SIP -> " + entry.getThreadName(), ERR_LOG_FILE_NOT_FOUND);
+                return;
+            }
+            try (FileOutputStream fileOutputStream = new FileOutputStream(logFileName, true)) {
+                OutputStreamWriter outputStream = new OutputStreamWriter(fileOutputStream);
+                outputStream.append(entry.getMsg());
+                outputStream.append("\n\n\n");
+                outputStream.flush();
+                outputStream.close();
+                fileOutputStream.flush();
+            } catch (Exception e) {
+                Logger.error("SIP -> " + entry.getThreadName(), ERR_LOG_FILE_NOT_FOUND);
+            }
+        }
     }
 
     /**

--- a/sipservice/src/main/java/com/phone/sip/SipServiceUtils.java
+++ b/sipservice/src/main/java/com/phone/sip/SipServiceUtils.java
@@ -1,6 +1,5 @@
 package com.phone.sip;
 
-import static com.phone.sip.SharedPreferenceConstant.ENABLE_SIP_LOGGING;
 import static com.phone.sip.constants.SipServiceConstants.H264_DEF_HEIGHT;
 import static com.phone.sip.constants.SipServiceConstants.H264_DEF_WIDTH;
 import static com.phone.sip.constants.SipServiceConstants.OPENH264_CODEC_ID;
@@ -37,11 +36,12 @@ public class SipServiceUtils {
      * Applies only for debug builds
      */
     public static void setSipLogger(Context context, EpConfig epConfig) {
-        if (SharedPreferencesHelper.getInstance(context).getBooleanPreference(ENABLE_SIP_LOGGING, false)) {
+        if (SharedPreferencesHelper.getInstance(context).getBooleanPreference(SharedPreferenceConstant.ENABLE_SIP_CONSOLE_LOGS, false)) {
             LogConfig logCfg = epConfig.getLogConfig();
-            sipLogger = new SipLogger();
+            sipLogger = new SipLogger(context);
             logCfg.setWriter(sipLogger);
             logCfg.setDecor(sipLogger.getDecor() | sipLogger.getDecor());
+            epConfig.setLogConfig(logCfg);
         }
     }
 

--- a/sipservice/src/main/java/com/phone/sip/constants/SipServiceConstants.java
+++ b/sipservice/src/main/java/com/phone/sip/constants/SipServiceConstants.java
@@ -171,8 +171,9 @@ public interface SipServiceConstants {
     String ERROR_INITIALIZE_MISSING_PARAMS = "Missing parameters required for library initialization. Please refer this document, https://github.com/phonedotcom/pdc-voip-android-sdk#4-phonecom-service-configuration-and-initialization";
     String ERR_MICROPHONE_PERMISSION_NOT_ALLOWED = "Microphone permission is not allowed by user. Please ask user to allow Microphone Permission in order to use the VOIP calling";
 
-    String ERR_WRITE_STORAGE_PERMISSION_NOT_ALLOWED = "Storage permission is not allowed by user to write file. Please ask user to allow External Storage Permission.";
-    String ERR_LOG_FILE_NOT_FOUND = "File not found to store logs, Please see the enable logging section from document here.";
+    String ERR_WRITE_STORAGE_PERMISSION_NOT_ALLOWED = "There is an error in creating or writing in the file, Please verify if storage permission is allowed or not by user to write file.";
+    String ERR_LOG_FILE_NOT_FOUND = "File not found to store logs, Please provide valid file path or see instruction on how to enable the SIP file logging from document.";
+    String ERR_LOG_FILE_FOUND_LOG_DISABLED = "Log file path is provided but File logging is disabled, Hence logs will not be written in the file.";
 
     long DELAY_ACCEPT_INCOMING_CALL = 1000L;
 }

--- a/sipservice/src/main/java/com/phone/sip/constants/SipServiceConstants.java
+++ b/sipservice/src/main/java/com/phone/sip/constants/SipServiceConstants.java
@@ -171,5 +171,8 @@ public interface SipServiceConstants {
     String ERROR_INITIALIZE_MISSING_PARAMS = "Missing parameters required for library initialization. Please refer this document, https://github.com/phonedotcom/pdc-voip-android-sdk#4-phonecom-service-configuration-and-initialization";
     String ERR_MICROPHONE_PERMISSION_NOT_ALLOWED = "Microphone permission is not allowed by user. Please ask user to allow Microphone Permission in order to use the VOIP calling";
 
+    String ERR_WRITE_STORAGE_PERMISSION_NOT_ALLOWED = "Storage permission is not allowed by user to write file. Please ask user to allow External Storage Permission.";
+    String ERR_LOG_FILE_NOT_FOUND = "File not found to store logs, Please see the enable logging section from document here.";
+
     long DELAY_ACCEPT_INCOMING_CALL = 1000L;
 }


### PR DESCRIPTION
Add the APIs to enable the verbose and file logging from SIP Library.
Used the SipLogger class which extended from LogWriter.
In, `write()` we have added the code for writing logs in filepath given from application side.