### PR TITLE
AND-3763 | Issue solved related to mute/unmute api, video feed crash and notification ongoing issue on call disconnect

### DIFF
--- a/sipservice/src/main/java/com/phone/sip/SipCall.java
+++ b/sipservice/src/main/java/com/phone/sip/SipCall.java
@@ -184,9 +184,10 @@ public class SipCall extends Call implements ICall {
             if (callState == pjsip_inv_state.PJSIP_INV_STATE_DISCONNECTED) {
                 account.getService().setLastCallStatus(0);
                 //delete();
-
+                if(account.noActiveCallPresent()){
+                    account.getService().stopForegroundService(account);
+                }
             }
-
         } catch (Exception exc) {
             Logger.error(LOG_TAG, "onCallState: error while getting call info", exc);
         }

--- a/sipservice/src/main/java/com/phone/sip/SipService.java
+++ b/sipservice/src/main/java/com/phone/sip/SipService.java
@@ -5,6 +5,7 @@ import static com.phone.sip.constants.PhoneComServiceConstants.SERVICE_FOREGROUN
 
 import android.Manifest;
 import android.app.Notification;
+import android.app.NotificationManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -14,6 +15,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.Looper;
+import android.service.notification.StatusBarNotification;
 import android.view.Surface;
 
 import androidx.core.app.NotificationCompat;
@@ -508,6 +510,12 @@ public class SipService extends BackgroundService implements SipServiceConstants
     }
 
     private void handleSetCallMute(Intent intent) {
+
+        Notification notification = getCurrentForegroundNotification();
+        if (notification != null) {
+            startForeground(notification);
+        }
+
         String accountID = intent.getStringExtra(PARAM_ACCOUNT_ID);
         SipAccount sipAccount;
         if (accountID == null) {
@@ -764,6 +772,10 @@ public class SipService extends BackgroundService implements SipServiceConstants
 
         final Bundle bundle = intent.getExtras();
         if (sipCall != null && bundle != null) {
+            Notification notification = getCurrentForegroundNotification();
+            if (notification != null) {
+                startForeground(notification);
+            }
             Logger.debug(TAG, "handleSetIncomingVideoFeed() -> Surface NOT NULL");
             Surface surface = bundle.getParcelable(PARAM_SURFACE);
             sipCall.setIncomingVideoFeed(surface);
@@ -1536,5 +1548,15 @@ public class SipService extends BackgroundService implements SipServiceConstants
             Logger.debug(TAG, "stopForegroundService() -> No Active Call Present");
             stopForegroundService(sipAccount);
         }
+    }
+
+    private Notification getCurrentForegroundNotification() {
+        NotificationManager notificationManager = (NotificationManager) this.getSystemService(NOTIFICATION_SERVICE);
+        for (StatusBarNotification notification : notificationManager.getActiveNotifications()) {
+            if (notification.getId() == SERVICE_FOREGROUND_NOTIFICATION_ID) {
+                return notification.getNotification();
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Solved multiple issue with this,
1. mute/unmute foreground service exception
2. incoming call video feed foreground service crash
3. permenant notification issue while call gets disconnected in background